### PR TITLE
Support custom input extensions for files

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ function ReactFilter (inputTree, options) {
 
   this.inputTree = inputTree;
   this.options = options || {};
-  if (options.extensions) {
+  if (this.options.extensions) {
     this.extensions = options.extensions;
   }
 }


### PR DESCRIPTION
My JSX files have a `.js` extension, but this filter currently only looks for `.jsx` files. This PR allows the extension to be configured:

``` js
appJs = filterReact(appJs, {
  extensions: ['js']
});
```
