### PR TITLE
printing error instead of crashing in case of syntax error

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,11 @@ ReactFilter.prototype.extensions = ['jsx'];
 ReactFilter.prototype.targetExtension = 'js';
 
 ReactFilter.prototype.processString = function (string) {
-  var result = react(string, this.transform);
+  try {
+    var result = react(string, this.transform);
+  } catch (exception) {
+    console.error("Error while compiling React tree: %s", exception);
+  }
 
   return result;
 };


### PR DESCRIPTION
when your template file contains an error, like a syntax error, broccoli will crash. I am try-catching this and printing an error instead, but possily emitting am error event would be preferable.

with the current test setup, i did not see how i could include a meaningful test for this case. To reproduce this, it's easiest to just put in some garbage html (like an unclosed tag) into an jsx file.
